### PR TITLE
[ISSUE-009] edit 명령 핸들러 구현

### DIFF
--- a/src/openclaw_archiver/cmd_edit.py
+++ b/src/openclaw_archiver/cmd_edit.py
@@ -2,7 +2,42 @@
 
 from __future__ import annotations
 
+from openclaw_archiver.db import get_archive_title, get_connection, update_archive_title
+
+_USAGE = "사용법: /archive edit <ID> <새 제목>"
+_NOT_FOUND = "해당 메세지를 찾을 수 없습니다. (ID: {id})"
+_BAD_ID = "ID는 숫자여야 합니다. 사용법: /archive edit <ID> <새 제목>"
+
 
 def handle(args: str, user_id: str) -> str:
     """Edit the title of an archived message."""
-    return ""
+    parts = args.strip().split(None, 1)
+
+    if len(parts) < 1 or not parts[0]:
+        return _USAGE
+
+    raw_id = parts[0]
+    try:
+        archive_id = int(raw_id)
+    except ValueError:
+        return _BAD_ID
+
+    if len(parts) < 2 or not parts[1].strip():
+        return _USAGE
+
+    new_title = parts[1].strip()
+
+    conn = get_connection()
+    try:
+        old_title = get_archive_title(conn, archive_id, user_id)
+        if old_title is None:
+            return _NOT_FOUND.format(id=archive_id)
+
+        update_archive_title(conn, archive_id, user_id, new_title)
+
+        return (
+            f"제목을 수정했습니다. (ID: {archive_id})\n"
+            f"        {old_title} → {new_title}"
+        )
+    finally:
+        conn.close()

--- a/src/openclaw_archiver/db.py
+++ b/src/openclaw_archiver/db.py
@@ -131,3 +131,26 @@ def search_archives_by_project(
         "ORDER BY a.created_at DESC",
         (user_id, project_id, f"%{keyword}%"),
     ).fetchall()
+
+
+def get_archive_title(
+    conn: sqlite3.Connection, archive_id: int, user_id: str
+) -> str | None:
+    """Get the title of an archive owned by user_id, or None if not found."""
+    row = conn.execute(
+        "SELECT title FROM archives WHERE id = ? AND user_id = ?",
+        (archive_id, user_id),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def update_archive_title(
+    conn: sqlite3.Connection, archive_id: int, user_id: str, new_title: str
+) -> bool:
+    """Update archive title. Returns True if a row was updated."""
+    cur = conn.execute(
+        "UPDATE archives SET title = ? WHERE id = ? AND user_id = ?",
+        (new_title, archive_id, user_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0

--- a/tests/test_cmd_edit.py
+++ b/tests/test_cmd_edit.py
@@ -1,0 +1,94 @@
+"""Tests for cmd_edit — /archive edit handler."""
+
+from __future__ import annotations
+
+import os
+
+from openclaw_archiver.cmd_edit import handle
+from openclaw_archiver.db import get_connection, insert_archive
+
+_USER_A = "U_EDIT_A"
+_USER_B = "U_EDIT_B"
+_USAGE = "사용법: /archive edit <ID> <새 제목>"
+
+
+def _seed_db(tmp_path: object) -> str:
+    db_path = os.path.join(str(tmp_path), "test.sqlite3")
+    conn = get_connection(db_path)
+    insert_archive(conn, _USER_A, None, "원래 제목", "https://example.com/1")
+    insert_archive(conn, _USER_B, None, "B의 메시지", "https://example.com/2")
+    conn.close()
+    return db_path
+
+
+class TestEditHappyPath:
+    """Verify successful edit scenarios."""
+
+    def test_edit_success(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        result = handle("1 새로운 제목", _USER_A)
+
+        assert "제목을 수정했습니다. (ID: 1)" in result
+        assert "원래 제목 → 새로운 제목" in result
+
+    def test_edit_updates_db(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        handle("1 수정된 제목", _USER_A)
+
+        conn = get_connection(db_path)
+        row = conn.execute(
+            "SELECT title FROM archives WHERE id = 1"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "수정된 제목"
+
+    def test_edit_with_spaces_in_title(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        result = handle("1 3월 스프린트 회의록 (수정)", _USER_A)
+
+        assert "3월 스프린트 회의록 (수정)" in result
+
+
+class TestEditErrors:
+    """Verify error handling."""
+
+    def test_edit_other_user_message(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        result = handle("2 해킹시도", _USER_A)
+
+        assert result == "해당 메세지를 찾을 수 없습니다. (ID: 2)"
+
+    def test_edit_nonexistent_id(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        result = handle("999 새제목", _USER_A)
+
+        assert result == "해당 메세지를 찾을 수 없습니다. (ID: 999)"
+
+    def test_edit_non_numeric_id(self) -> None:
+        result = handle("abc 새제목", _USER_A)
+        assert result == "ID는 숫자여야 합니다. 사용법: /archive edit <ID> <새 제목>"
+
+    def test_edit_missing_new_title(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        db_path = _seed_db(tmp_path)
+        monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+        result = handle("1", _USER_A)
+        assert result == _USAGE
+
+    def test_edit_empty_args(self) -> None:
+        result = handle("", _USER_A)
+        assert result == _USAGE
+
+    def test_edit_id_only_with_spaces(self) -> None:
+        result = handle("1   ", _USER_A)
+        assert result == _USAGE


### PR DESCRIPTION
Closes #17

## Summary
- `cmd_edit.py`: `/archive edit <ID> <새 제목>` 핸들러 구현
  - ID 정수 검증, 소유권 확인 (user_id 필터)
  - 존재 여부 비노출 (타인 소유 = 미존재 동일 에러)
  - 성공 시 이전→새 제목 표시
- `db.py`에 `get_archive_title()`, `update_archive_title()` 추가
- 9개 새 테스트 (전체 124개 통과)

## Test plan
- [x] 제목 수정 성공 → 응답에 ID/이전/새 제목
- [x] DB에 새 제목 반영 확인
- [x] 공백 포함 제목 정상 수정
- [x] 타인 소유 메시지 → 찾을 수 없음
- [x] 존재하지 않는 ID → 찾을 수 없음
- [x] 비숫자 ID → 에러
- [x] 새 제목 누락/빈 args → 사용법 안내

🤖 Generated with [Claude Code](https://claude.com/claude-code)