### PR TITLE
feat(cmd_save): mrkdwn bold labels for save response

### DIFF
--- a/src/openclaw_archiver/cmd_save.py
+++ b/src/openclaw_archiver/cmd_save.py
@@ -25,10 +25,10 @@ def handle(args: str, user_id: str) -> str:
 
         lines = [
             f"저장했습니다. (ID: {archive_id})",
-            f"        제목: {title}",
+            f"*제목:* {title}",
         ]
         if project:
-            lines.append(f"        프로젝트: {project}")
+            lines.append(f"*프로젝트:* {project}")
 
         return "\n".join(lines)
     finally:


### PR DESCRIPTION
## Summary
- Remove 8-space indentation from save success response
- Use `*제목:*` and `*프로젝트:*` mrkdwn bold labels

Closes #40

## Test plan
- [ ] Test assertions will be updated in ISSUE-024

🤖 Generated with [Claude Code](https://claude.com/claude-code)