### PR TITLE
feat(project-cmds): mrkdwn format for project command responses

### DIFF
--- a/src/openclaw_archiver/cmd_project_delete.py
+++ b/src/openclaw_archiver/cmd_project_delete.py
@@ -24,7 +24,7 @@ def handle(args: str, user_id: str) -> str:
 
         result = f'"{name}" 프로젝트를 삭제했습니다.'
         if unlinked > 0:
-            result += f"\n        {unlinked}건의 메세지가 미분류로 변경되었습니다."
+            result += f"\n{unlinked}건의 메세지가 미분류로 변경되었습니다."
 
         return result
     finally:

--- a/src/openclaw_archiver/cmd_project_list.py
+++ b/src/openclaw_archiver/cmd_project_list.py
@@ -21,9 +21,9 @@ def handle(args: str, user_id: str) -> str:
         if not projects:
             return _EMPTY
 
-        lines = [f"프로젝트 ({len(projects)}개)", f"        {SEPARATOR}"]
+        lines = [f"*프로젝트* ({len(projects)}개)", SEPARATOR]
         for name, count in projects:
-            lines.append(f"        {name}     {count}건")
+            lines.append(f"{name} — {count}건")
 
         return "\n".join(lines)
     finally:

--- a/src/openclaw_archiver/cmd_project_rename.py
+++ b/src/openclaw_archiver/cmd_project_rename.py
@@ -35,6 +35,6 @@ def handle(args: str, user_id: str) -> str:
             # Should not happen after require_project, but defensive
             return f'"{old_name}" 프로젝트를 찾을 수 없습니다.'
 
-        return f"프로젝트 이름을 변경했습니다.\n        {old_name} → {new_name}"
+        return f"프로젝트 이름을 변경했습니다.\n*변경:* {old_name} → {new_name}"
     finally:
         conn.close()


### PR DESCRIPTION
## Summary
- cmd_project_list: bold header `*프로젝트*`, em-dash item format `name — count건`
- cmd_project_rename: `*변경:*` bold label
- cmd_project_delete: remove 8-space indentation from unlinked message

Closes #45

## Test plan
- [ ] Test assertions will be updated in ISSUE-024

🤖 Generated with [Claude Code](https://claude.com/claude-code)