### PR TITLE
feat(cmd_help): rewrite help text with Slack mrkdwn

### DIFF
--- a/src/openclaw_archiver/cmd_help.py
+++ b/src/openclaw_archiver/cmd_help.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
-from openclaw_archiver.formatters import SEPARATOR
-
 _HELP_TEXT = (
-    "/archive 사용법\n"
-    f"        {SEPARATOR}\n"
-    "        저장    /archive save <제목> <링크> [/p <프로젝트>]\n"
-    "        목록    /archive list [/p <프로젝트>]\n"
-    "        검색    /archive search <키워드> [/p <프로젝트>]\n"
-    "        수정    /archive edit <ID> <새 제목>\n"
-    "        삭제    /archive remove <ID>\n"
+    "*/archive 사용법*\n"
+    "───\n"
+    "*저장* /archive save <제목> <링크> [/p <프로젝트>]\n"
+    "*목록* /archive list [/p <프로젝트>]\n"
+    "*검색* /archive search <키워드> [/p <프로젝트>]\n"
+    "*수정* /archive edit <ID> <새 제목>\n"
+    "*삭제* /archive remove <ID>\n"
     "\n"
-    "        프로젝트 관리\n"
-    f"        {SEPARATOR}\n"
-    "        목록    /archive project list\n"
-    "        이름변경 /archive project rename <기존이름> <새이름>\n"
-    "        삭제    /archive project delete <프로젝트이름>"
+    "*프로젝트 관리*\n"
+    "───\n"
+    "*목록* /archive project list\n"
+    "*이름변경* /archive project rename <기존이름> <새이름>\n"
+    "*삭제* /archive project delete <프로젝트이름>"
 )
 
 


### PR DESCRIPTION
## Summary
- Rewrite entire help text to match ux_spec.md Section 4.9
- Use bold headers `*/archive 사용법*`, `*프로젝트 관리*`
- Use bold command labels `*저장*`, `*목록*`, etc.
- Remove all 8-space indentation

Closes #46

## Test plan
- [ ] Test assertions will be updated in ISSUE-024

🤖 Generated with [Claude Code](https://claude.com/claude-code)