### PR TITLE
feat(cmd_list,cmd_search): mrkdwn bold headers and separator

### DIFF
--- a/src/openclaw_archiver/cmd_list.py
+++ b/src/openclaw_archiver/cmd_list.py
@@ -38,7 +38,7 @@ def _list_all(conn, user_id: str) -> str:  # type: ignore[no-untyped-def]
         return _EMPTY_ALL
 
     count = len(rows)
-    header = [f"저장된 메세지 ({count}건)", f"        {SEPARATOR}"]
+    header = [f"*저장된 메세지* ({count}건)", SEPARATOR]
     items = format_archive_rows(rows, include_project=True)
     return "\n".join(header + items)
 
@@ -54,8 +54,8 @@ def _list_by_project(conn, user_id: str, project_name: str) -> str:  # type: ign
 
     count = len(rows)
     header = [
-        f"저장된 메세지 — {project_name} ({count}건)",
-        f"        {SEPARATOR}",
+        f"*저장된 메세지 — {project_name}* ({count}건)",
+        SEPARATOR,
     ]
     items = format_archive_rows(rows, include_project=False)
     return "\n".join(header + items)

--- a/src/openclaw_archiver/cmd_search.py
+++ b/src/openclaw_archiver/cmd_search.py
@@ -43,7 +43,7 @@ def _search_all(conn, user_id: str, keyword: str) -> str:  # type: ignore[no-unt
         return _NO_RESULT.format(keyword=keyword)
 
     count = len(rows)
-    header = [f'검색 결과: "{keyword}" ({count}건)', f"        {SEPARATOR}"]
+    header = [f'*검색 결과: "{keyword}"* ({count}건)', SEPARATOR]
     items = format_archive_rows(rows, include_project=True)
     return "\n".join(header + items)
 
@@ -61,8 +61,8 @@ def _search_by_project(
 
     count = len(rows)
     header = [
-        f'검색 결과: "{keyword}" — {project_name} ({count}건)',
-        f"        {SEPARATOR}",
+        f'*검색 결과: "{keyword}" — {project_name}* ({count}건)',
+        SEPARATOR,
     ]
     items = format_archive_rows(rows, include_project=False)
     return "\n".join(header + items)


### PR DESCRIPTION
## Summary
- cmd_list: bold headers `*저장된 메세지*` and `*저장된 메세지 — {project}*`
- cmd_search: bold headers `*검색 결과: "{keyword}"*` etc.
- Remove 8-space indentation from SEPARATOR lines

Closes #49

## Test plan
- [ ] Test assertions will be updated in ISSUE-024

🤖 Generated with [Claude Code](https://claude.com/claude-code)