### PR TITLE
test: NFR-008 mrkdwn compliance tests and assertion updates

### DIFF
--- a/tests/test_cmd_help.py
+++ b/tests/test_cmd_help.py
@@ -27,8 +27,8 @@ class TestHelp:
     def test_contains_header_and_separator(self) -> None:
         result = handle("", "U_TEST")
 
-        assert "/archive 사용법" in result
-        assert "─────────────────────────────" in result
+        assert "*/archive 사용법*" in result
+        assert "───" in result
 
     def test_contains_project_management_section(self) -> None:
         result = handle("", "U_TEST")

--- a/tests/test_cmd_list.py
+++ b/tests/test_cmd_list.py
@@ -39,7 +39,7 @@ class TestListAll:
 
         result = handle("", _USER_A)
 
-        assert "저장된 메세지 (3건)" in result
+        assert "*저장된 메세지* (3건)" in result
         assert "스프린트 회의록" in result
         assert "코드 리뷰 가이드" in result
         assert "미분류 메모" in result
@@ -58,7 +58,7 @@ class TestListAll:
 
         result = handle("", _USER_A)
 
-        assert "프로젝트: Backend" in result
+        assert "Backend" in result
 
     def test_list_all_shows_unclassified(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         db_path = _seed_db(tmp_path)
@@ -76,8 +76,8 @@ class TestListAll:
 
         # Check format elements.
         assert "#" in result  # ID prefix
-        assert "https://slack.com/" in result  # Link
-        assert "─────" in result  # Separator
+        assert "<https://slack.com/" in result  # Slack link format
+        assert "───" in result  # Separator
 
     def test_list_all_empty(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         db_path = os.path.join(str(tmp_path), "empty.sqlite3")
@@ -99,7 +99,7 @@ class TestListByProject:
 
         result = handle("/p Backend", _USER_A)
 
-        assert "저장된 메세지 — Backend (2건)" in result
+        assert "*저장된 메세지 — Backend* (2건)" in result
         assert "스프린트 회의록" in result
         assert "코드 리뷰 가이드" in result
         assert "미분류 메모" not in result

--- a/tests/test_cmd_project_list.py
+++ b/tests/test_cmd_project_list.py
@@ -39,7 +39,7 @@ class TestProjectListHappyPath:
 
         result = handle("", _USER_A)
 
-        assert "프로젝트 (2개)" in result
+        assert "*프로젝트* (2개)" in result
         assert "Backend" in result
         assert "2건" in result
         assert "Frontend" in result
@@ -52,7 +52,7 @@ class TestProjectListHappyPath:
         result = handle("", _USER_A)
 
         # User A should see 2 projects, not User B's
-        assert "프로젝트 (2개)" in result
+        assert "*프로젝트* (2개)" in result
 
     def test_user_b_sees_own_projects(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         db_path = _seed_db(tmp_path)
@@ -60,7 +60,7 @@ class TestProjectListHappyPath:
 
         result = handle("", _USER_B)
 
-        assert "프로젝트 (1개)" in result
+        assert "*프로젝트* (1개)" in result
         assert "Backend" in result
         assert "1건" in result
 
@@ -70,7 +70,7 @@ class TestProjectListHappyPath:
 
         result = handle("", _USER_A)
 
-        assert "─────────────────────────────" in result
+        assert "───" in result
 
 
 class TestProjectListEmpty:

--- a/tests/test_cmd_save.py
+++ b/tests/test_cmd_save.py
@@ -43,7 +43,7 @@ class TestSaveHappyPath:
 
         assert "저장했습니다." in result
         assert "회의록" in result
-        assert "프로젝트: Backend" in result
+        assert "*프로젝트:* Backend" in result
 
     def test_save_creates_project_automatically(self, tmp_path: object, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         db_path = _make_db(tmp_path)

--- a/tests/test_cmd_search.py
+++ b/tests/test_cmd_search.py
@@ -37,7 +37,7 @@ class TestSearchAll:
 
         result = handle("회의록", _USER_A)
 
-        assert '검색 결과: "회의록" (2건)' in result
+        assert '*검색 결과: "회의록"* (2건)' in result
         assert "스프린트 회의록" in result
         assert "주간 회의록 정리" in result
 
@@ -74,7 +74,7 @@ class TestSearchAll:
 
         result = handle("스프린트", _USER_A)
 
-        assert "프로젝트: Backend" in result
+        assert "Backend" in result
         assert "#" in result
 
 
@@ -87,7 +87,7 @@ class TestSearchByProject:
 
         result = handle("회의록 /p Backend", _USER_A)
 
-        assert '검색 결과: "회의록" — Backend (1건)' in result
+        assert '*검색 결과: "회의록" — Backend* (1건)' in result
         assert "스프린트 회의록" in result
         assert "주간 회의록 정리" not in result
 

--- a/tests/test_mrkdwn_compliance.py
+++ b/tests/test_mrkdwn_compliance.py
@@ -1,0 +1,310 @@
+"""NFR-008 mrkdwn compliance tests.
+
+Validates that all command responses conform to Slack mrkdwn formatting rules:
+- No 4+ space indentation in output
+- No backticks in output
+- No bare URLs (all URLs wrapped in Slack link format <url|text>)
+- Slack link format present where URLs appear
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+from openclaw_archiver.plugin import handle_message
+
+_USER = "U_MRKDWN_TEST"
+
+# Patterns that should NOT appear in any output.
+_FOUR_SPACE_INDENT = re.compile(r"^ {4,}", re.MULTILINE)
+_BACKTICK = re.compile(r"`")
+_BARE_URL = re.compile(r"(?<![<|])https?://\S+(?![>|])")
+
+# Pattern that SHOULD appear when URLs are present.
+_SLACK_LINK = re.compile(r"<https?://[^|>]+\|[^>]+>")
+
+
+@pytest.fixture(autouse=True)
+def _mrkdwn_db(tmp_path, monkeypatch):
+    """Set up a temporary DB for mrkdwn compliance tests."""
+    from openclaw_archiver.db import get_connection
+
+    db_path = os.path.join(str(tmp_path), "mrkdwn.sqlite3")
+    conn = get_connection(db_path)
+    conn.close()
+    monkeypatch.setenv("OPENCLAW_ARCHIVER_DB_PATH", db_path)
+
+
+def _assert_no_indentation(text: str, context: str) -> None:
+    """Assert no 4+ space indentation exists in text."""
+    match = _FOUR_SPACE_INDENT.search(text)
+    assert match is None, (
+        f"Found 4+ space indentation in {context}: "
+        f"line={text.splitlines()[text[:match.start()].count(chr(10))]!r}"
+    )
+
+
+def _assert_no_backticks(text: str, context: str) -> None:
+    """Assert no backticks exist in text."""
+    assert "`" not in text, f"Found backtick in {context}: {text!r}"
+
+
+def _assert_no_bare_urls(text: str, context: str) -> None:
+    """Assert no bare URLs exist (all should be Slack link format)."""
+    match = _BARE_URL.search(text)
+    assert match is None, (
+        f"Found bare URL in {context}: {match.group()!r}"
+    )
+
+
+class TestSaveMrkdwn:
+    """NFR-008: save command responses use mrkdwn."""
+
+    def test_save_no_indentation(self) -> None:
+        resp = handle_message(
+            "/archive save 테스트메모 https://slack.com/a/1", _USER
+        )
+        assert resp is not None
+        _assert_no_indentation(resp, "save response")
+        _assert_no_backticks(resp, "save response")
+
+    def test_save_with_project_no_indentation(self) -> None:
+        resp = handle_message(
+            "/archive save 메모 https://slack.com/a/2 /p TestProj", _USER
+        )
+        assert resp is not None
+        _assert_no_indentation(resp, "save with project response")
+        _assert_no_backticks(resp, "save with project response")
+
+    def test_save_bold_labels(self) -> None:
+        resp = handle_message(
+            "/archive save 볼드테스트 https://slack.com/a/3 /p BoldProj", _USER
+        )
+        assert resp is not None
+        assert "*제목:*" in resp
+        assert "*프로젝트:*" in resp
+
+
+class TestListMrkdwn:
+    """NFR-008: list command responses use mrkdwn."""
+
+    def test_list_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 목록테스트 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive list", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "list response")
+        _assert_no_backticks(resp, "list response")
+
+    def test_list_no_bare_urls(self) -> None:
+        handle_message(
+            "/archive save 링크테스트 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive list", _USER)
+        assert resp is not None
+        _assert_no_bare_urls(resp, "list response")
+
+    def test_list_has_slack_links(self) -> None:
+        handle_message(
+            "/archive save 슬랙링크 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive list", _USER)
+        assert resp is not None
+        assert _SLACK_LINK.search(resp), f"No Slack link format found in: {resp}"
+
+    def test_list_bold_header(self) -> None:
+        handle_message(
+            "/archive save 헤더테스트 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive list", _USER)
+        assert resp is not None
+        assert "*저장된 메세지*" in resp
+
+    def test_list_by_project_bold_header(self) -> None:
+        handle_message(
+            "/archive save 프로젝트테스트 https://slack.com/a/1 /p MyProj", _USER
+        )
+        resp = handle_message("/archive list /p MyProj", _USER)
+        assert resp is not None
+        assert "*저장된 메세지 — MyProj*" in resp
+
+    def test_list_separator_is_short(self) -> None:
+        handle_message(
+            "/archive save 구분선 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive list", _USER)
+        assert resp is not None
+        assert "───" in resp
+
+
+class TestSearchMrkdwn:
+    """NFR-008: search command responses use mrkdwn."""
+
+    def test_search_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 검색대상 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive search 검색", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "search response")
+        _assert_no_backticks(resp, "search response")
+
+    def test_search_no_bare_urls(self) -> None:
+        handle_message(
+            "/archive save 검색링크 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive search 검색", _USER)
+        assert resp is not None
+        _assert_no_bare_urls(resp, "search response")
+
+    def test_search_bold_header(self) -> None:
+        handle_message(
+            "/archive save 검색볼드 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive search 검색", _USER)
+        assert resp is not None
+        assert re.search(r'\*검색 결과: ".+"\*', resp), f"No bold header in: {resp}"
+
+
+class TestEditMrkdwn:
+    """NFR-008: edit command responses use mrkdwn."""
+
+    def test_edit_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 수정전 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive edit 1 수정후", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "edit response")
+        _assert_no_backticks(resp, "edit response")
+
+    def test_edit_bold_label(self) -> None:
+        handle_message(
+            "/archive save 원래제목 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive edit 1 새제목", _USER)
+        assert resp is not None
+        assert "*변경:*" in resp
+
+
+class TestRemoveMrkdwn:
+    """NFR-008: remove command responses use mrkdwn."""
+
+    def test_remove_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 삭제대상 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive remove 1", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "remove response")
+        _assert_no_backticks(resp, "remove response")
+
+    def test_remove_bold_label(self) -> None:
+        handle_message(
+            "/archive save 삭제제목 https://slack.com/a/1", _USER
+        )
+        resp = handle_message("/archive remove 1", _USER)
+        assert resp is not None
+        assert "*제목:*" in resp
+
+
+class TestProjectListMrkdwn:
+    """NFR-008: project list command responses use mrkdwn."""
+
+    def test_project_list_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p Proj1", _USER
+        )
+        resp = handle_message("/archive project list", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "project list response")
+        _assert_no_backticks(resp, "project list response")
+
+    def test_project_list_bold_header(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p Proj1", _USER
+        )
+        resp = handle_message("/archive project list", _USER)
+        assert resp is not None
+        assert "*프로젝트*" in resp
+
+    def test_project_list_em_dash_format(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p Proj1", _USER
+        )
+        resp = handle_message("/archive project list", _USER)
+        assert resp is not None
+        assert "Proj1 — 1건" in resp
+
+
+class TestProjectRenameMrkdwn:
+    """NFR-008: project rename command responses use mrkdwn."""
+
+    def test_rename_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p OldName", _USER
+        )
+        resp = handle_message("/archive project rename OldName NewName", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "project rename response")
+        _assert_no_backticks(resp, "project rename response")
+
+    def test_rename_bold_label(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p RenameOld", _USER
+        )
+        resp = handle_message("/archive project rename RenameOld RenameNew", _USER)
+        assert resp is not None
+        assert "*변경:*" in resp
+
+
+class TestProjectDeleteMrkdwn:
+    """NFR-008: project delete command responses use mrkdwn."""
+
+    def test_delete_no_indentation(self) -> None:
+        handle_message(
+            "/archive save 메모 https://slack.com/a/1 /p DelProj", _USER
+        )
+        resp = handle_message("/archive project delete DelProj", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "project delete response")
+        _assert_no_backticks(resp, "project delete response")
+
+
+class TestHelpMrkdwn:
+    """NFR-008: help command response uses mrkdwn."""
+
+    def test_help_no_indentation(self) -> None:
+        resp = handle_message("/archive help", _USER)
+        assert resp is not None
+        _assert_no_indentation(resp, "help response")
+        _assert_no_backticks(resp, "help response")
+
+    def test_help_bold_title(self) -> None:
+        resp = handle_message("/archive help", _USER)
+        assert resp is not None
+        assert "*/archive 사용법*" in resp
+
+    def test_help_bold_section_headers(self) -> None:
+        resp = handle_message("/archive help", _USER)
+        assert resp is not None
+        assert "*프로젝트 관리*" in resp
+
+    def test_help_bold_command_labels(self) -> None:
+        resp = handle_message("/archive help", _USER)
+        assert resp is not None
+        assert "*저장*" in resp
+        assert "*목록*" in resp
+        assert "*검색*" in resp
+        assert "*수정*" in resp
+        assert "*삭제*" in resp
+        assert "*이름변경*" in resp
+
+    def test_help_short_separator(self) -> None:
+        resp = handle_message("/archive help", _USER)
+        assert resp is not None
+        assert "───" in resp

--- a/tests/test_ux_messages.py
+++ b/tests/test_ux_messages.py
@@ -16,7 +16,7 @@ from openclaw_archiver.plugin import handle_message
 _USER = "U_UX_TEST"
 
 _DATE_RE = r"\d{4}-\d{2}-\d{2}"
-_SEPARATOR = "─────────────────────────────"
+_SEPARATOR = "───"
 
 
 @pytest.fixture(autouse=True)
@@ -44,10 +44,10 @@ class TestSaveSuccess:
             _USER,
         )
         assert resp is not None
-        # Pattern: 저장했습니다. (ID: {id})\n        제목: {title}
+        # Pattern: 저장했습니다. (ID: {id})\n*제목:* {title}
         assert "저장했습니다. (ID:" in resp
-        assert "제목: 스프린트 회의록" in resp
-        assert "프로젝트:" not in resp
+        assert "*제목:* 스프린트 회의록" in resp
+        assert "*프로젝트:*" not in resp
 
     def test_save_with_project(self) -> None:
         resp = handle_message(
@@ -56,8 +56,8 @@ class TestSaveSuccess:
         )
         assert resp is not None
         assert "저장했습니다. (ID:" in resp
-        assert "제목: 스프린트 회의록" in resp
-        assert "프로젝트: Backend" in resp
+        assert "*제목:* 스프린트 회의록" in resp
+        assert "*프로젝트:* Backend" in resp
 
 
 class TestEditSuccess:
@@ -283,7 +283,7 @@ class TestListFormatting:
         )
         resp = handle_message("/archive list", _USER)
         assert resp is not None
-        assert "저장된 메세지 (2건)" in resp
+        assert "*저장된 메세지* (2건)" in resp
         assert _SEPARATOR in resp
 
     def test_list_date_format(self) -> None:
@@ -326,7 +326,7 @@ class TestListFormatting:
         )
         resp = handle_message("/archive search 검색", _USER)
         assert resp is not None
-        assert '검색 결과: "검색" (1건)' in resp
+        assert '*검색 결과: "검색"* (1건)' in resp
 
 
 class TestProjectListFormatting:
@@ -342,7 +342,7 @@ class TestProjectListFormatting:
         )
         resp = handle_message("/archive project list", _USER)
         assert resp is not None
-        assert "프로젝트 (2개)" in resp
+        assert "*프로젝트* (2개)" in resp
         assert "1건" in resp
 
 
@@ -357,7 +357,7 @@ class TestHelpMessage:
     def test_help_contains_all_commands(self) -> None:
         resp = handle_message("/archive help", _USER)
         assert resp is not None
-        assert "/archive 사용법" in resp
+        assert "*/archive 사용법*" in resp
         assert _SEPARATOR in resp
         assert "/archive save" in resp
         assert "/archive list" in resp
@@ -434,7 +434,7 @@ class TestEndToEnd:
         )
         assert resp is not None
         assert "저장했습니다" in resp
-        assert "프로젝트: LifeProj" in resp
+        assert "*프로젝트:* LifeProj" in resp
 
         # List in project
         resp = handle_message("/archive list /p LifeProj", _USER)


### PR DESCRIPTION
## Summary
- Update 20 existing test assertions across 6 test files to match new mrkdwn output format
- Add `tests/test_mrkdwn_compliance.py` with 27 new NFR-008 validation tests
- All 259 tests pass (232 updated + 27 new)

## NFR-008 compliance checks
- No 4+ space indentation in any command output
- No backticks in any command output
- No bare URLs (all use Slack `<url|text>` format)
- Bold headers and labels present in all responses
- Short separator `───` used consistently

Closes #51

## Test plan
- [x] `uv run pytest -q` passes with 259 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)